### PR TITLE
changes necessary for cloudera cdh 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ Here are links to more information on Cloudera Impala:
 - Java (>= 1.5)
 - R (>= 2.7.0)
 - rJava (>= 0.5-0)
-- Impala [JDBC driver jars](https://downloads.cloudera.com/impala-jdbc/impala-jdbc-0.5-2.zip)
+- Impala [JDBC driver jars](impala-jdbc-cdh5.zip)
 
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,25 +18,31 @@
                 <dependency>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
-                        <version>1.0.4</version>
+                        <version>1.1.3</version>
                 </dependency>
 
                 <dependency>
                         <groupId>org.apache.hive</groupId>
                         <artifactId>hive-jdbc</artifactId>
-                        <version>0.10.0-cdh4.2.1</version>
+                        <version>0.12.0-cdh5.1.0</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                    <version>2.3.0-cdh5.1.0</version>
                 </dependency>
 
                 <dependency>
                         <groupId>org.apache.hive</groupId>
                         <artifactId>hive-metastore</artifactId>
-                        <version>0.10.0-cdh4.2.1</version>
+                        <version>0.12.0-cdh5.1.0</version>
                 </dependency>
 
                 <dependency>
                         <groupId>org.apache.hive</groupId>
                         <artifactId>hive-service</artifactId>
-                        <version>0.10.0-cdh4.2.1</version>
+                        <version>0.12.0-cdh5.1.0</version>
                 </dependency>
 
                 <dependency>
@@ -48,7 +54,7 @@
                 <dependency>
                         <groupId>org.apache.thrift</groupId>
                         <artifactId>libthrift</artifactId>
-                        <version>0.9.0</version>
+                        <version>0.9.0.cloudera.2</version>
                 </dependency>
 
                 <dependency>
@@ -60,13 +66,13 @@
                 <dependency>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
-                        <version>1.6.4</version>
+                        <version>1.7.5</version>
                 </dependency>
 
                 <dependency>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
-                        <version>1.6.1</version>
+                        <version>1.7.5</version>
                 </dependency>
 
         </dependencies>


### PR DESCRIPTION
Thanks for the effort on RImpala. I have been using it fine with CDH 4.x.x. But recently we switched to CDH 5.1.0 and current RImpala is not compatible. I found that the problem is from dependency. In this pull request, I modified pom.xml and added the zip file containing latest jar files. It has been tested with no problem from our end.

Please test it and let me know if you have any concern.
