### PR TITLE
Enable LDAP connection string building in rimpala.connect()

### DIFF
--- a/src/R/RImpala.R
+++ b/src/R/RImpala.R
@@ -71,15 +71,20 @@ rimpala.query <-function (Q="show tables",isDDL="false",fetchSize="10000") {
   }
 }
 
-rimpala.connect <- function(IP="localhost",port="21050",principal="noSasl"){
+rimpala.connect <- function(IP="localhost",port="21050",principal="noSasl",user="none",password="none"){
   impalaObj = .jnew("com.musigma.ird.bigdata.RImpala")
   
   #building the connection string
   #concat auth= or principal= depending on the user input to argument principal
-  if(principal=="noSasl")
+  if(principal=="noSasl" & user=="none")
   {
     principal = paste("auth=",principal,sep="");
-  } else  {
+  }
+  else if(principal=="noSasl" & user!="none")
+  {
+    principal = paste("user=",user,";","password=",password,sep="")
+  } 
+  else  {
     principal = paste("principal=",principal,sep="");
   }
   

--- a/src/R/RImpala.R
+++ b/src/R/RImpala.R
@@ -71,7 +71,7 @@ rimpala.query <-function (Q="show tables",isDDL="false",fetchSize="10000") {
   }
 }
 
-rimpala.connect <- function(IP="localhost",port="21050",principal="noSasl",user="none",password="none"){
+rimpala.connect <- function(IP="localhost",port="21050",principal="noSasl",user="none",password="none",db="default"){
   impalaObj = .jnew("com.musigma.ird.bigdata.RImpala")
   
   #building the connection string
@@ -82,7 +82,7 @@ rimpala.connect <- function(IP="localhost",port="21050",principal="noSasl",user=
   }
   else if(principal=="noSasl" & user!="none")
   {
-    principal = paste("user=",user,";","password=",password,sep="")
+    principal = paste(db,";","user=",user,";","password=",password,sep="")
   } 
   else  {
     principal = paste("principal=",principal,sep="");


### PR DESCRIPTION
I wanted to make building an LDAP connection string possible without changing anything in your Java code. Now if someone uses rimpala.connect(user="someuser",password="somepassword",db="somedb"), the "principal" string when user and password are defined will look like "somedb;user=someuser;password=somepassword". In RImpala.java, the appropriate connection string for LDAP will be created. 

CONNECTION_URL = "jdbc:hive2://" + IP + ':' + port + "/;" + principal;

In this example the full string would become:
"jdbc:hive2://localhost:21050/somedb;user=someuser;password=somepassword"

This follows the appropriate convention for an LDAP connection string as shown in the Impala JDBC docs:
"jdbc:hive2://myhost.example.com:21050/test_db;user=fred;password=xyz123"

http://www.cloudera.com/documentation/enterprise/5-2-x/topics/impala_jdbc.html

If a user parameter is not entered in rimpala.connect(), the existing logic for building the "principal" string still takes place. 
